### PR TITLE
Evaluate auc

### DIFF
--- a/peepholelib/utils/analyze.py
+++ b/peepholelib/utils/analyze.py
@@ -113,6 +113,17 @@ def evaluate(**kwargs):
 
     return np.linalg.norm(y1-y2), np.linalg.norm(y1-y2)
 
+def compute_top_k_accuracy(peepholes, targets, k):
+    """
+    peepholes: (Tensor [n_samples, n_classes])
+    targets: (Tensor [n_samples]) - true class labels
+    k: (int) - top-k to compute
+    """
+    topk = torch.topk(peepholes, k=k, dim=1).indices
+    targets = targets.unsqueeze(1).expand_as(topk)
+    correct = (topk == targets).any(dim=1).float()
+    return correct.mean().item()
+
 def conceptogram_ghl_score(**kwargs):
     phs = kwargs['peepholes']
     cvs = kwargs['corevectors']

--- a/peepholelib/utils/analyze.py
+++ b/peepholelib/utils/analyze.py
@@ -1,7 +1,6 @@
 # Stuff used in evaluation ... will get out from here
 from collections import Counter
 import numpy as np
-from sklearn.metrics import roc_auc_score
 
 # plotting stuff
 from matplotlib import pyplot as plt
@@ -11,6 +10,7 @@ import pandas as pd
 # torch stuff
 import torch
 from torch.distributions import Categorical
+from torcheval.metrics import AUC
 from torch.nn.functional import  softmax as sm
 
 # TODO: give a better name
@@ -283,12 +283,11 @@ def conceptogram_cl_score(**kwargs):
         metrics['m_ko'][ds_key] = kos.mean()
         metrics['s_ko'][ds_key] = kos.std()
 
-        results_np = results.detach().cpu().numpy().astype(int)
-        scores_np = scores.detach().cpu().numpy()
-
         try:
-            auc = roc_auc_score(results_np, scores_np)
-        except ValueError:
+            auc_metric = AUC()
+            auc_metric.update(scores.detach().cpu(), results.to(dtype=torch.int32).detach().cpu())
+            auc = auc_metric.compute().item()
+        except Exception:
             auc = float('nan')
         metrics['auc'][ds_key] = auc
 


### PR DESCRIPTION
- conceptogram_cl_score now returns scores, metrics - instead of scores, m_ok, s_ok, m_ko, s_ko
- metrics is a dict where the keys are the possible quantities; auc score has been added to the old metrics

- conceptogram_ghl_score remains unchanged so far

- compute_top_k_accuracy has been added; needed for tuning to get the best config (cv_dim, n_clusters)
- need to wait for xp_tuning.py to be fully updated in the XAI repo