### PR TITLE
Minor

### DIFF
--- a/peepholelib/peepholes/peepholes.py
+++ b/peepholelib/peepholes/peepholes.py
@@ -79,7 +79,7 @@ class Peepholes:
                 if verbose: print('loader n_samples: ', n_samples) 
                 self.path.mkdir(parents=True, exist_ok=True)
                 self._phs[ds_key] = PersistentTensorDict(filename=file_path, batch_size=[n_samples], mode='w')
-            continue 
+
             modules_to_compute = []
             for module in self.target_modules:
                 if not module in self._phs[ds_key]:

--- a/peepholelib/peepholes/peepholes.py
+++ b/peepholelib/peepholes/peepholes.py
@@ -71,7 +71,7 @@ class Peepholes:
             # create/load PersistentTensorDict file
             if file_path.exists():
                 if verbose: print(f'File {file_path} exists. Loading from disk.')
-                self._phs[ds_key] = PersistentTensorDict.from_h5(file_path, mode='r+')
+                self._phs[ds_key] = PersistentTensorDict.from_h5(file_path, mode='r')
                 n_samples = len(self._phs[ds_key])
                 if verbose: print('loaded n_samples: ', n_samples)
             else:
@@ -97,6 +97,10 @@ class Peepholes:
                 else:
                     if verbose: print(f'Peepholes for {module} already present. Skipping.')
 
+            if len(modules_to_compute) == 0:
+                if verbose: print(f'No modules to compute for {ds_key}. Skipping.')
+                continue
+
             # Close PTD create with mode 'w' and re-open it with mode 'r+'
             # This is done so we can use multiple workers for reading and writting
             self._phs[ds_key].close()
@@ -109,10 +113,6 @@ class Peepholes:
             dl_phs = DataLoader(self._phs[ds_key], batch_size=bs, collate_fn=lambda x:x, num_workers = n_threads)
             dl_cvs = DataLoader(cvds, batch_size=bs, collate_fn=lambda x: x, num_workers = n_threads)
             dl_dss = DataLoader(dssds, batch_size=bs, collate_fn=lambda x: x, num_workers = n_threads)
-
-            if len(modules_to_compute) == 0:
-                if verbose: print(f'No modules to compute for {ds_key}. Skipping.')
-                continue
 
             if verbose: print(f'\n ---- computing peepholes for modules {modules_to_compute}\n')
             for _cvs, _dss, phs in tqdm(zip(dl_cvs, dl_dss, dl_phs), disable=not verbose, total=ceil(n_samples/bs)):

--- a/peepholelib/peepholes/peepholes.py
+++ b/peepholelib/peepholes/peepholes.py
@@ -79,7 +79,7 @@ class Peepholes:
                 if verbose: print('loader n_samples: ', n_samples) 
                 self.path.mkdir(parents=True, exist_ok=True)
                 self._phs[ds_key] = PersistentTensorDict(filename=file_path, batch_size=[n_samples], mode='w')
-            
+            continue 
             modules_to_compute = []
             for module in self.target_modules:
                 if not module in self._phs[ds_key]:

--- a/peepholelib/tests/PTD/chunk.py
+++ b/peepholelib/tests/PTD/chunk.py
@@ -1,0 +1,58 @@
+from tensordict import PersistentTensorDict as PTD
+from tensordict import MemoryMappedTensor as MMT
+
+import torch
+from torch.utils.data import DataLoader
+import h5py
+
+from pathlib import Path
+from time import time
+
+####
+# what we learn
+# 1. chuncks seem to help, but does not work with data of different shapes
+# 2. auto chuncking works, but we have implications on the time
+# 3. external divides into small files, but sort of buggy depending on the size (cs)
+
+if __name__ == '__main__':
+    ns = 2**15
+    ds = 2**8
+    cs = 2**13
+    bs = 2**5
+    it = 10
+    fn = Path('./data/banana')
+    device = torch.device('cuda:0')
+    
+    if fn.exists():
+        td = PTD.from_h5(filename=fn, mode='r')
+        print('loading')
+    else:
+        print('n samples: ', ns)
+        nc = ns//cs
+        external = [(f'data/{i}', i*cs, cs) for i in range(nc)]
+        if ns-cs*nc > 0:
+            external += [(f'data/{nc}', cs*nc, ns-cs*nc)]
+        print(external, cs*nc, ns-cs*nc)
+
+        td = PTD(filename=fn, batch_size=[ns], mode='w', external=external) 
+        td['a'] = MMT.empty(shape=(ns, ds)) 
+        td['b'] = MMT.empty(shape=(ns, 1)) 
+        
+        dl = DataLoader(td, batch_size=bs, collate_fn=lambda x: x)
+        for d in dl:
+            d['a'] = torch.rand(d.shape[0], ds)
+            d['b'] = torch.rand(d.shape[0], 1)
+
+    print('computing')
+
+    ts = []
+    idx = torch.randperm(ns) 
+    x = torch.zeros(ds, device=device)
+    for i in range(it):
+        t0 = time()
+        x += td[idx[i]]['a'].to(device)/it
+        t = time()-t0
+        ts.append(t)
+    print('mean time: ', torch.tensor(ts).mean())
+
+


### PR DESCRIPTION
Open `phs` on read-only, and re-open it on `r+` only if it needs to be rewritten.

It solves bugs when multiple processes try to open the `phs` concurrently, and all modules are already computed, which happens quite often during tuning.