### PR TITLE
add retry load time

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -18,6 +18,7 @@
 - Implement dimentionality reduction base.
 
 ## Peepholes
+- Add `retry_load_time` to sleep on a load fail. Usefull for tuning.
 - Model's modules are saved in different PTDs
 - add Flag to control wether or not call `_compute_empirical_posteriors()` in classifiers' `fit()`. 
 - Classifiers now call `compute_empirical_posteriors` inside `fit` to have a common interface with `DMD`.

--- a/peepholelib/datasets/functional/transforms.py
+++ b/peepholelib/datasets/functional/transforms.py
@@ -150,7 +150,7 @@ mobilenet_v2_transform = transforms.Compose([
     transforms.CenterCrop(224),
     ]) 
 
-mobilenet_v2_cifar10_augumentations = transforms.Compose([
+mobilenet_v2_cifar10_augmentations = transforms.Compose([
     transforms.Resize(256),
     transforms.CenterCrop(224),
     transforms.AutoAugment(policy=transforms.AutoAugmentPolicy.CIFAR10), 

--- a/peepholelib/datasets/parsedDataset.py
+++ b/peepholelib/datasets/parsedDataset.py
@@ -109,7 +109,7 @@ class ParsedDataset():
             
                     if verbose: print(f'All {existing_chunks} chunks for {ds_key} already exist. Loading from disk.')
                     for chunk_path in existing_chunks:
-                        ptd = PersistentTensorDict.from_h5(chunk_path, mode='r+')
+                        ptd = PersistentTensorDict.from_h5(chunk_path, mode='r')
                         ptd.batch_size = torch.Size((len(ptd),))
                         shards.append(ptd)
                 else:

--- a/peepholelib/peepholes/peepholes.py
+++ b/peepholelib/peepholes/peepholes.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from tqdm import tqdm
 from math import ceil
+from time import sleep
 
 # torch stuff
 import torch
@@ -48,6 +49,7 @@ class Peepholes:
         - drillers (dict(str: peepholelib.peepholes.drill_base.DrillBase)):Dictionary where keys are the modules as in `model.state_dict` and values are classes extending `DrillBase`.
         - names dict(str:str): Dictionary with key being the module name, and value being a name to append to the PTD file with the peepholes. Peepholes will be saved in a file with name `<loader>/<key>.<name>. If `None` it is ignored. Defaults to `None`.
         - batchsize (int): batchsize to process `corevectors` into `peepholes`. Defaults to 64.
+        - retry_load_time (int): Time (in seconds) to wait before retrying loading an already existing PTD with peepholes. If `None` no further attempts are done. Defaults to `None`.
         - n_threads (int): Number of threads to pass as `num_workers` to `torch.utils.data.DataLoader`. Defaults to 1.
         - verbose (bool): print progress messages
         '''
@@ -59,10 +61,9 @@ class Peepholes:
         self._drillers = kwargs['drillers']
         names = kwargs.get('names', None)
         bs = kwargs.get('batch_size', 64)
+        rlt = kwargs.get('retry_load_time', None)
         n_threads = kwargs.get('n_threads', 1)
-
         verbose = kwargs.get('verbose', False)
-        target_modules = kwargs['target_modules'] # list of peep modules
 
         if loaders == None: loaders = list(cvs._corevds.keys())
 
@@ -85,7 +86,18 @@ class Peepholes:
                 # create/load PersistentTensorDict file
                 if file_path.exists():
                     if verbose: print(f'File {file_path} exists. Loading from disk.')
-                    _td = PersistentTensorDict.from_h5(file_path, mode='r')
+
+                    if rlt == None:
+                        _td = PersistentTensorDict.from_h5(file_path, mode='r')
+                    else:
+                        while True:
+                            try: 
+                                _td = PersistentTensorDict.from_h5(file_path, mode='r')
+                                break
+                            except BlockingIOError:
+                                if verbose: print(f'Seems like the file {file_path} is busy. Will wait {rlt} seconds and try again.')
+                                sleep(rlt)
+
                     n_samples = len(_td)
                 else:
                     n_samples = len(cvs._corevds[ds_key])

--- a/peepholelib/training/validationLoops.py
+++ b/peepholelib/training/validationLoops.py
@@ -1,5 +1,4 @@
 from time import time
-from math import isinf
 import torch
 
 def DefaultValidationLoop(**kwargs):


### PR DESCRIPTION
Add an argument to `get_peepholes()` that makes it retry loading `PTD`s in case the file is busy.
This situation occurs quite often during tuning, especially after the `PTD`s' module-wise separation.

- add `rlt`
- update release notes
- fix typo