### PR TITLE
solves atks bugs

### DIFF
--- a/peepholelib/datasets/parsedDataset.py
+++ b/peepholelib/datasets/parsedDataset.py
@@ -418,30 +418,26 @@ class ParsedDataset():
                 _n_samples = len(self._dss[ds_key])
 
             else: 
-                if len(inf_names[ds_key]) == 0:
-                    self._dss[ds_key].set_transform(transforms[ds_key] if transforms != None and ds_key in transforms else None)
-                    _n_samples = len(self._dss[ds_key])
-                else:
-                    for inf_name in inf_names[ds_key]:
-                        # back up the pointer to the original ds
-                        if (not (ds_key in self._dss_ori.keys())) and (ds_key in self._dss.keys()):
-                            self._dss_ori[ds_key] = self._dss.pop(ds_key)
-                        
-                        inf_ds_key = ds_key + '-' + inf_name
+                for inf_name in inf_names[ds_key]:
+                    # back up the pointer to the original ds
+                    if (not (ds_key in self._dss_ori.keys())) and (ds_key in self._dss.keys()):
+                        self._dss_ori[ds_key] = self._dss.pop(ds_key)
+                    
+                    inf_ds_key = ds_key + '-' + inf_name
 
-                        # create new StackedDS copying the pointer to the original parsed DS
-                        self._dss[inf_ds_key] = _StackedDS(ori=self._dss_ori[ds_key].ori)
-                        self._dss[inf_ds_key].set_transform(transforms[ds_key] if transforms != None and ds_key in transforms else None)
+                    # create new StackedDS copying the pointer to the original parsed DS
+                    self._dss[inf_ds_key] = _StackedDS(ori=self._dss_ori[ds_key].ori)
+                    self._dss[inf_ds_key].set_transform(transforms[ds_key] if transforms != None and ds_key in transforms else None)
 
-                        # stack inference values — single H5 file
-                        inf_path = self.path / f'dss.{ds_key}.{inf_name}'
-                        if verbose: print(f'Loading inference for {inf_ds_key} from {inf_path}.')
-                        _td = PersistentTensorDict.from_h5(inf_path, mode=mode)
-                        _td.batch_size = torch.Size((len(_td),))
+                    # stack inference values — single H5 file
+                    inf_path = self.path / f'dss.{ds_key}.{inf_name}'
+                    if verbose: print(f'Loading inference for {inf_ds_key} from {inf_path}.')
+                    _td = PersistentTensorDict.from_h5(inf_path, mode=mode)
+                    _td.batch_size = torch.Size((len(_td),))
 
-                        self._dss[inf_ds_key].stack_inference(inf=_td)
+                    self._dss[inf_ds_key].stack_inference(inf=_td)
 
-                    _n_samples = len(self._dss[inf_ds_key])
+                _n_samples = len(self._dss[inf_ds_key])
             if verbose: print('loaded n_samples: ', _n_samples)
         return
     

--- a/peepholelib/models/model_wrap.py
+++ b/peepholelib/models/model_wrap.py
@@ -91,7 +91,7 @@ class ModelWrap(nn.Module):
 
         # send model to device
         self._model = self._model.to(self.device)
-        self._model.eval()
+        self.eval()
 
         # set in __call__()
         self._acts = None


### PR DESCRIPTION
Solves the bug with parsing multiple attacks, leading to extremely poor attack success rates.

Bug source: `ModelWrap` was calling `model._model.eval()` in its initialization, leaving the attribute `ModelWrap.training` set to `True` (default), this attribute is inherited from `nn.Module`. Even though the layers are set with `requires_grad = False` in the `__init__()`, through `self.set_requires_grad()`, other attributes (maybe normalization, and dropout layers) were left with `requires_grad=True`.

Problems it caused: Attacks from `torchattacks` use the gradient and backpropagation, changing the attributes not set with `requires_grad=False`. Therefore, applying an attack changes the prediction for the original images, which completely messes with the `attack_success` computations.

The solution is simple: see the change in `ModelWrap`.

I also cleaned up the `load_only()` on `ParsedDataset` a bit.