### PR TITLE
Null dim red

### DIFF
--- a/peepholelib/coreVectors/coreVectors.py
+++ b/peepholelib/coreVectors/coreVectors.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from tqdm import tqdm
 from math import ceil
+from time import sleep
 
 # torch stuff
 import torch
@@ -53,6 +54,7 @@ class CoreVectors():
         - activations_parser (callable): A function for parsing activations. Defaults to 'get_in_activations()' (see peepholelib.models.model_wrap.py for details on how we get the activations).
         - names dict(str:str): Dictionary with key being the module name, and value being a name to append to the PTD file with the corevectors. Corevectors will be saved in a file with name `<loader>/<key>.<name>. If `None` it is ignored. Defaults to `None`.
         - batch_size (int): Creates dataloader to do computation in batch size. Defaults to 64.
+        - retry_load_time (int): Time (in seconds) to wait before retrying loading an already existing PTD with corevectors. If `None` no further attempts are done. Defaults to `None`.
         - n_threads (int): 'num_workers' passed to 'torch.utils.data.DataLoader'. Defaults to 1.
         - verbose (bool): print progress messages.
         '''
@@ -64,11 +66,12 @@ class CoreVectors():
         reducers = kwargs.get('reducers')
         activations_parser = kwargs.get('activations_parser', get_in_activations)
         names = kwargs.get('names', None)
-        bs = kwargs.get('batch_size', 64) 
-        n_threads = kwargs.get('n_threads', 1) 
+        bs = kwargs.get('batch_size', 64)
+        rlt = kwargs.get('retry_load_time', None)
+        n_threads = kwargs.get('n_threads', 1)
         save_input = kwargs.get('save_input', True)
-        save_output = kwargs.get('save_output', False) 
-        verbose = kwargs.get('verbose', False) 
+        save_output = kwargs.get('save_output', False)
+        verbose = kwargs.get('verbose', False)
     
         model = self._model 
         device = self._model.device 
@@ -107,7 +110,18 @@ class CoreVectors():
 
                 if file_path.exists():
                     if verbose: print(f'File {file_path} exists. Loading from disk.')
-                    _td = PersistentTensorDict.from_h5(file_path, mode='r')
+
+                    if rlt == None:
+                        _td = PersistentTensorDict.from_h5(file_path, mode='r')
+                    else:
+                        while True:
+                            try:
+                                _td = PersistentTensorDict.from_h5(file_path, mode='r')
+                                break
+                            except BlockingIOError:
+                                if verbose: print(f'Seems like the file {file_path} is busy. Will wait {rlt} seconds and try again.')
+                                sleep(rlt)
+
                     n_samples = len(_td)
                 else:
                     n_samples = len(datasets._dss[ds_key])

--- a/peepholelib/coreVectors/dimReduction/null.py
+++ b/peepholelib/coreVectors/dimReduction/null.py
@@ -1,0 +1,29 @@
+# Our stuff
+from .dim_reduction_base import DimReductionBase as DRB 
+
+class Null(DRB):
+    def __init__(self, **kwargs):
+        DRB.__init__(self, **kwargs)
+        
+        # just to asset that the layer is Conv2d
+        layer = kwargs['layer']
+        model = kwargs['model']
+
+        return
+
+    def __call__(self, **kwargs):
+        """
+        Simply flatten without any reduction. 
+        """
+        # Assuming the class token is the first token in the sequence
+
+        act_data = kwargs['act_data'] 
+        return act_data.flatten()
+
+    def parser(self, **kwargs):
+        cvs = kwargs['cvs']
+        dss = kwargs.get('dss', None)
+        label_key = kwargs.get('label_key', 'label') 
+                                                            
+        ret = cvs if dss == None else (cvs, dss[label_key])
+        return ret

--- a/peepholelib/coreVectors/dimReduction/null.py
+++ b/peepholelib/coreVectors/dimReduction/null.py
@@ -17,8 +17,8 @@ class Null(DRB):
         """
         # Assuming the class token is the first token in the sequence
 
-        act_data = kwargs['act_data'] 
-        return act_data.flatten()
+        act_data = kwargs['act_data']
+        return act_data.flatten(start_dim=1)
 
     def parser(self, **kwargs):
         cvs = kwargs['cvs']

--- a/peepholelib/coreVectors/dimReduction/svds/conv2d_avg_kernel_svd.py
+++ b/peepholelib/coreVectors/dimReduction/svds/conv2d_avg_kernel_svd.py
@@ -31,7 +31,7 @@ class Conv2dAvgKernelSVD(DRB):
 
         if file_path.exists():
             if verbose: print(f'File {file_path} exists. Loading from disk.')
-            self._svd = torch.load(file_path)
+            self._svd = torch.load(file_path, weights_only=True)
         else: 
             if not isinstance(_layer, torch.nn.Conv2d):
                 raise RuntimeError("Only Conv2D is suported") 

--- a/peepholelib/coreVectors/dimReduction/svds/conv2d_kernel_svd.py
+++ b/peepholelib/coreVectors/dimReduction/svds/conv2d_kernel_svd.py
@@ -31,7 +31,7 @@ class Conv2dKernelSVD(DRB):
 
         if file_path.exists():
             if verbose: print(f'File {file_path} exists. Loading from disk.')
-            self._svd = torch.load(file_path)
+            self._svd = torch.load(file_path, weights_only=True)
         else: 
             if not isinstance(_layer, torch.nn.Conv2d):
                 raise RuntimeError("Only Conv2D is suported") 

--- a/peepholelib/coreVectors/dimReduction/svds/conv2d_toeplitz_svd.py
+++ b/peepholelib/coreVectors/dimReduction/svds/conv2d_toeplitz_svd.py
@@ -32,7 +32,7 @@ class Conv2dToeplitzSVD(DRB):
 
         if file_path.exists():
             if verbose: print(f'File {file_path} exists. Loading from disk.')
-            self._svd = torch.load(file_path)
+            self._svd = torch.load(file_path, weights_only=True)
         else: 
             # Turn on activation saving
             model.set_activations(save_input=True, save_output=False)

--- a/peepholelib/coreVectors/dimReduction/svds/linear_svd.py
+++ b/peepholelib/coreVectors/dimReduction/svds/linear_svd.py
@@ -27,7 +27,7 @@ class LinearSVD(DRB):
 
         if file_path.exists():
             if verbose: print(f'File {file_path} exists. Loading from disk.')
-            self._svd = torch.load(file_path)
+            self._svd = torch.load(file_path, weights_only=True)
         else: 
             # computation
             W = torch.hstack((_layer.weight, _layer.bias.reshape(-1,1))).to(device)

--- a/peepholelib/coreVectors/dimReduction/svds/vit_linear_svd.py
+++ b/peepholelib/coreVectors/dimReduction/svds/vit_linear_svd.py
@@ -38,7 +38,7 @@ class ViTLinearSVD(DRB):
 
         if file_path.exists():
             if verbose: print(f'File {file_path} exists. Loading from disk.')
-            self._svd = torch.load(file_path)
+            self._svd = torch.load(file_path, weights_only=True)
         else: 
             # computation
             W = _layer.weight

--- a/peepholelib/peepholes/DeepMahalanobisDistance/DMD.py
+++ b/peepholelib/peepholes/DeepMahalanobisDistance/DMD.py
@@ -57,8 +57,8 @@ class DeepMahalanobisDistance(DrillBase):
     def load(self, **kwargs):
         # return true or false if DMD is fitted or not
         if self.mean_path.exists() and self.precision_path.exists():
-            self._means = torch.load(self.mean_path).to(self.device)
-            self._precision = torch.load(self.precision_path).to(self.device)
+            self._means = torch.load(self.mean_path, weights_only=True).to(self.device)
+            self._precision = torch.load(self.precision_path, weights_only=True).to(self.device)
             ok = True
         else:
             ok = False

--- a/peepholelib/peepholes/classifiers/classifier_base.py
+++ b/peepholelib/peepholes/classifiers/classifier_base.py
@@ -33,7 +33,7 @@ class ClassifierBase(DrillBase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def load(self, **kwargs):
         if self._empp_file.exists():
-            self._empp = torch.load(self._empp_file).to(self.device)
+            self._empp = torch.load(self._empp_file, weights_only=True).to(self.device)
         return 
 
     @abc.abstractmethod

--- a/peepholelib/peepholes/peepholes.py
+++ b/peepholelib/peepholes/peepholes.py
@@ -195,6 +195,7 @@ class Peepholes:
         self.check_uncontexted()
         
         target_modules = kwargs.get('target_modules', None)
+        invert = kwargs.get('invert', False)
         verbose = kwargs.get('verbose', False)
 
         if self._phs == {}:
@@ -219,6 +220,9 @@ class Peepholes:
                     raise ValueError(f"Peepholes for module {module} do not exist. Please run get_peepholes() first.")
 
             _conceptograms[ds_key] = torch.stack([self._phs[ds_key][layer] for layer in target_modules], dim=1)
+
+            if invert:
+                _conceptograms[ds_key] = 1 - _conceptograms[ds_key]
 
         return _conceptograms
 

--- a/peepholelib/scores/dmd.py
+++ b/peepholelib/scores/dmd.py
@@ -230,6 +230,7 @@ def DMD_score(**kwargs):
     pos_loader_test = kwargs.get('pos_loader_test', 'test')
     neg_loaders = kwargs['neg_loaders']
     target_modules = kwargs.get('target_modules', None)
+    invert = kwargs.get('invert', False)
     append_scores = kwargs.get('append_scores', None)
     score_name = kwargs.get('score_name', 'DMD')
 
@@ -256,6 +257,10 @@ def DMD_score(**kwargs):
     train_pos = torch.stack([phs._phs[pos_loader_train][layer].max(dim=1)[0] for layer in target_modules], dim=1)
     test_pos = torch.stack([phs._phs[pos_loader_test][layer].max(dim=1)[0] for layer in target_modules], dim=1)
 
+    if invert:
+        train_pos = 1 - train_pos
+        test_pos = 1 - test_pos
+
     nps = len(train_pos) # number of positive samples
 
     for neg_test_key, neg_train_loaders in neg_loaders.items():
@@ -269,12 +274,17 @@ def DMD_score(**kwargs):
             idx = torch.randperm(len(_train_neg))
             train_neg.append(_train_neg[idx[i*nspnl:(i+1)*nspnl]])
         train_neg = torch.vstack(train_neg)
+        if invert:
+            train_neg = 1 - train_neg
 
         # train data and labels
         train_data = torch.vstack((train_pos, train_neg))
         train_label = torch.hstack((torch.ones(len(train_pos)), torch.zeros(len(train_neg))))
+
         # test data
         test_neg = torch.stack([phs._phs[neg_test_key][layer].max(dim=1)[0] for layer in target_modules], dim=1)
+        if invert:
+            test_neg = 1 - test_neg
         test_data = torch.vstack((test_pos, test_neg))
 
         _, y_test = __DMD_score__(

--- a/peepholelib/scores/protoclass.py
+++ b/peepholelib/scores/protoclass.py
@@ -51,10 +51,7 @@ def conceptogram_protoclass_score(**kwargs):
     # computations
     #-----------
     # get conceptogram 
-    cpss = phs.get_conceptograms(loaders=loaders, target_modules=target_modules, verbose=verbose)
-
-    if invert:
-        cpss = 1 - cpss
+    cpss = phs.get_conceptograms(loaders=loaders, target_modules=target_modules, invert=invert, verbose=verbose)
 
     # sizes and values just to facilitate 
     nd = cpss[loaders[0]].shape[1] # number of layers (distributions)

--- a/peepholelib/scores/protoclass.py
+++ b/peepholelib/scores/protoclass.py
@@ -28,6 +28,7 @@ def conceptogram_protoclass_score(**kwargs):
     target_modules = kwargs.get('target_modules', None)
     proto_key = kwargs.get('proto_key', 'train')
     proto_th = kwargs.get('proto_threshold', 0.9)
+    invert = kwargs.get('invert', False)
     append_scores = kwargs.get('append_scores', None)
     score_name = kwargs.get('score_name', 'Proto-Class')
     proto = kwargs.get('proto', None) #TODO: is this used? remove
@@ -51,6 +52,9 @@ def conceptogram_protoclass_score(**kwargs):
     #-----------
     # get conceptogram 
     cpss = phs.get_conceptograms(loaders=loaders, target_modules=target_modules, verbose=verbose)
+
+    if invert:
+        cpss = 1 - cpss
 
     # sizes and values just to facilitate 
     nd = cpss[loaders[0]].shape[1] # number of layers (distributions)

--- a/peepholelib/scores/protoclass.py
+++ b/peepholelib/scores/protoclass.py
@@ -12,7 +12,7 @@ def conceptogram_protoclass_score(**kwargs):
     - loaders (list[str]): loaders to consider, usually ['train', 'test', 'val'], if 'None', gets all loaders in 'peepholes._phs'. Defaults to 'None'.
     - target_modules (list[str]): list if target modules, as keys from the model `statedict`.
     - proto_key (str): The key in `loaders` to get compute the protoclasses from.
-    - proto_th (float): Model's confidence threshold to select samples for the protoclass computation ('0 <= proto_th <= 1').
+    - proto_threshold (float): Model's confidence threshold to select samples for the protoclass computation ('0 <= proto_threshold <= 1'). Raises a `RuntimeError` if no correctly classified sample passes the threshold for some class. Defaults to 0.9.
     - append_scores (dict): Append the scores form this dictionaty to the scores computed in this function. Overwrite if same keys.
     - verbose (bool): print progress messages.
     - proto proto: Protoclasses, an array of shape '(nc, nd, nc)', with 'nc' the number of classes and 'nd' the number of modules in 'target_modules'. Each element in the first dim is the protoclass of the respective label.
@@ -66,7 +66,10 @@ def conceptogram_protoclass_score(**kwargs):
         for i in range(nc):
             cl = torch.logical_and(labels == i, results == 1)
             idx = torch.logical_and(cl, confs>proto_th)
-            
+
+            if idx.sum() == 0:
+                raise RuntimeError(f'No correctly classified samples with confidence > {proto_th} in "{proto_key}" for class {i}. Consider lowering `proto_threshold`.')
+
             _p = cps[idx].sum(dim=0)  ## P'_j
             _p /= _p.sum(dim=1, keepdim=True)
             proto[i][:] = _p[:]


### PR DESCRIPTION
Add a `null` dimensionality reduction; it is equivalent to taking the raw activations.

Add `weights_only=False` to torch's `load()` call to handle warnings.

Add the option to invert the peepholes for `proto` and `dmd` scores, in case we have peepholes with inverted logic (representing cost or risk rather than confidence).
